### PR TITLE
Fix for https://github.com/anenasa/pyppasearch/issues/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To use it one should install Python 3 packages using `sudo apt-get install pytho
 This script will search from https://launchpad.net/ubuntu/+ppas, and then get packages information from each PPA, including package name, version and Ubuntu codename and CPU architecture.
 
 ## Usage
+```
 usage: pyppasearch.py [-h] [-c CODENAME] [-a ARCH] package
 
 positional arguments:
@@ -18,3 +19,4 @@ optional arguments:
                         First word of Ubuntu code name, e.g. Focal
   -a ARCH, --arch ARCH  CPU architecture, one of amd64, i386, armhf, arm64,
                         etc.
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # pyppasearch
 Simple python script for searching PPA
 
+To use it one should install Python 3 packages using `sudo apt-get install python3-requests python3-bs4 python3-launchpadlib`.
+
 ## Description
-This script will search from https://launchpad.net/ubuntu/+ppas, and then get packages information from each PPA, including package name, version and Ubuntu codename.
+This script will search from https://launchpad.net/ubuntu/+ppas, and then get packages information from each PPA, including package name, version and Ubuntu codename and CPU architecture.
 
 ## Usage
 usage: pyppasearch.py [-h] [-c CODENAME] [-a ARCH] package

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Simple python script for searching PPA
 This script will search from https://launchpad.net/ubuntu/+ppas, and then get packages information from each PPA, including package name, version and Ubuntu codename.
 
 ## Usage
-    usage: pyppasearch.py [-h] [-c CODENAME] package
-    
-    positional arguments:
-      package               exact name of the package you want to search
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -c CODENAME, --codename CODENAME
-                            First word of Ubuntu code name, e.g. Focal     
+usage: pyppasearch.py [-h] [-c CODENAME] [-a ARCH] package
+
+positional arguments:
+  package               exact name of the package you want to search
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CODENAME, --codename CODENAME
+                        First word of Ubuntu code name, e.g. Focal
+  -a ARCH, --arch ARCH  CPU architecture, one of amd64, i386, armhf, arm64,
+                        etc.

--- a/pyppasearch.py
+++ b/pyppasearch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import argparse
 import requests
 from bs4 import BeautifulSoup
-import argparse
-
+from launchpadlib.launchpad import Launchpad
 
 class Repo:
     def __init__(self, user, name, url):
@@ -11,25 +11,17 @@ class Repo:
         self.name = name
         self.url = url
 
-    def search(self, search):
-        resp = requests.get(self.url)
-        soup = BeautifulSoup(resp.text, "html.parser")
-        thead = soup.select("thead > tr > th")
-        series_index = 3
-        # Sometimes there is "Uploader" in table, so position of index will change
-        for j in range(len(thead)):
-            if thead[j].text == "Series":
-                series_index = j
-                break
-        results = soup.select("tbody > tr.archive_package_row")
+    def search(self, lp, codename, cpu_arch, search):
+        owner = lp.people[self.user]
+        archive = owner.getPPAByName(distribution=lp.distributions["ubuntu"], name=self.name)
+        desired_dist_and_arch = 'https://api.launchpad.net/devel/ubuntu/' + codename + '/' + cpu_arch
+        binaries = archive.getPublishedBinaries(status='Published',distro_arch_series=desired_dist_and_arch)
+
         packages = []
-        for result in results:
-            source = result.select_one("a.sprite").text
-            name = source.split()[0]
-            version = source.split()[2]
-            series = result.select_one(f"td:nth-of-type({series_index + 2})").text
-            if name == search:
-                packages.append(Package(self.user, self.name, name, version, series))
+        if len(binaries) > 0:
+            for binary in binaries:
+                if binary.binary_package_name == search:
+                    packages.append(Package(self.user, self.name, binary.binary_package_name, binary.binary_package_version, codename))
         return packages
 
 
@@ -58,17 +50,18 @@ def search_ppa(search):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--codename", type=str, help="First word of Ubuntu code name, e.g. Focal")
+    parser.add_argument("-a", "--arch", type=str, help="CPU architecture, one of amd64, i386, armhf, arm64, etc.")
     parser.add_argument("package", type=str, help="exact name of the package you want to search")
     args = parser.parse_args()
+
+    lp = Launchpad.login_anonymously("ppa-search", "edge", "~/.launchpadlib/cache/", version="devel")
 
     repos = search_ppa(args.package)
     for i in range(len(repos)):
         print(f"\rSearching {i + 1}/{len(repos)}", end='')
-
-        packages = repos[i].search(args.package)
+        packages = repos[i].search(lp, args.codename.lower(), args.arch, args.package)
         for package in packages:
-            if args.codename is None or package.series == args.codename:
-                print(f"\r{package.name} {package.version} {package.user}/{package.repo} {package.series}")
+            print(f"\r{package.name} {package.version} ppa:{package.user}/{package.repo} {package.series.capitalize()} ({args.arch})")
 
     print("\rSearch is finished.")
 

--- a/pyppasearch.py
+++ b/pyppasearch.py
@@ -15,13 +15,12 @@ class Repo:
         owner = lp.people[self.user]
         archive = owner.getPPAByName(distribution=lp.distributions["ubuntu"], name=self.name)
         desired_dist_and_arch = 'https://api.launchpad.net/devel/ubuntu/' + codename + '/' + cpu_arch
-        binaries = archive.getPublishedBinaries(status='Published',distro_arch_series=desired_dist_and_arch)
+        binaries = archive.getPublishedBinaries(status='Published',distro_arch_series=desired_dist_and_arch, binary_name=search, exact_match=True)
 
         packages = []
         if len(binaries) > 0:
             for binary in binaries:
-                if binary.binary_package_name == search:
-                    packages.append(Package(self.user, self.name, binary.binary_package_name, binary.binary_package_version, codename))
+                packages.append(Package(self.user, self.name, binary.binary_package_name, binary.binary_package_version, codename))
         return packages
 
 


### PR DESCRIPTION
I have replaced search function and some other parts of the Script. 
It currently uses `launchpadlib`. 
Also I have added CPU architecture command line option.

Currently we have exactly same results as Y PPA Manager gives:

```
./pyppasearch.py -c Bionic -a amd64 i3-gaps
i3-gaps 4.17.1-1ubuntu1~ppa5 ppa:regolith-linux/experimental Bionic (amd64)
i3-gaps 4.18.2-1~regolith2 ppa:rynojvr/ppa Bionic (amd64)
i3-gaps 4.17.1-1ubuntu1~ppa4 ppa:kgilmer/regolith-unstable Bionic (amd64)
i3-gaps 4.17.1-1ubuntu1~ppa5 ppa:regolith-linux/regolith-1.4.1 Bionic (amd64)
i3-gaps 4.17.1-1ubuntu1~ppa5 ppa:regolith-linux/r1.3 Bionic (amd64)
i3-gaps 4.19.1-1ubuntu1 ppa:regolith-linux/release Bionic (amd64)
i3-gaps 4.19.1-1ubuntu1 ppa:regolith-linux/stable Bionic (amd64)
i3-gaps 4.19.1-1ubuntu1 ppa:regolith-linux/unstable Bionic (amd64)
i3-gaps 4.17.1-1ubuntu1~ppa5 ppa:a-weller/regolithtest Bionic (amd64)
i3-gaps 4.18.2-1~regolith2 ppa:kgilmer/speed-ricer Bionic (amd64)
i3-gaps 4.17.1-1ubuntu1~ppa4 ppa:kgilmer/regolith-stable Bionic (amd64)
i3-gaps 4.17.1-0york0~18.04 ppa:jonathonf/i3 Bionic (amd64)
Search is finished.
```

(ordering is different, but contents are exactly the same)

Thank you!
---

Details about `launchpadlib` maybe found here:

* https://api.launchpad.net/devel.html
* https://help.launchpad.net/API/launchpadlib
* https://bazaar.launchpad.net/~nilarimogard/y-ppa-manager/stable/view/head:/ppastats.py
