### PR TITLE
Add pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+#https://pypi.org/project/requests/
+requests
+
+#https://pypi.org/project/beautifulsoup4/
+beautifulsoup4
+
+#https://pypi.org/project/launchpadlib/
+launchpadlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 #https://pypi.org/project/requests/
-requests
+requests>=2.28.1
 
 #https://pypi.org/project/beautifulsoup4/
-beautifulsoup4
+beautifulsoup4>=4.11.1
 
 #https://pypi.org/project/launchpadlib/
-launchpadlib
+launchpadlib>=1.1.0


### PR DESCRIPTION
This is a neat tool. I generally prefer using pip to installing via apt-get since I can use virtualenvs, so I looked up the pypl packages referenced by the ubuntu installs you listed in the README.
The minimum versions from pip freeze are probably very conservative but I haven't tested them with anything earlier. These are the known to work. Tested with:
```

$ python3 -m virtualenv venv && ( . ./venv/bin/activate && pip install -r requirements.txt && python3 pyppasearch.py --noexact insync )
insync-beta-ubuntu 0.9.23.1~quantal ppa:trebelnik-stefina/myppa Quantal (i386)
insync-beta-ubuntu 0.9.23.1~quantal ppa:trebelnik-stefina/myppa Quantal (amd64)
Search is finished.
```
